### PR TITLE
Add whitespace validation to form fields

### DIFF
--- a/ECommercePlateform.Server/src/Infrastructure/Persistence/Repositories/CityRepository.cs
+++ b/ECommercePlateform.Server/src/Infrastructure/Persistence/Repositories/CityRepository.cs
@@ -54,14 +54,13 @@ namespace ECommercePlateform.Server.src.Infrastructure.Persistence.Repositories
         public async Task<bool> IsNameUniqueInStateAsync(string name, Guid stateId)
         {
             return !await _context.Cities
-                .AnyAsync(c => c.Name.ToLower() == name.ToLower() && c.StateId == stateId && !c.IsDeleted);
+                .AnyAsync(c => c.Name.ToLower().Trim() == name.ToLower().Trim() && c.StateId == stateId && !c.IsDeleted);
         }
 
         public async Task<bool> IsNameUniqueInStateAsync(string name, Guid stateId, Guid excludeId)
         {
             return !await _context.Cities
-                .AnyAsync(c => c.Name.ToLower() == name.ToLower() && c.StateId == stateId && c.Id != excludeId && !c.IsDeleted);
+                .AnyAsync(c => c.Name.ToLower().Trim() == name.ToLower().Trim() && c.StateId == stateId && c.Id != excludeId && !c.IsDeleted);
         }
-
     }
 }

--- a/ECommercePlateform.Server/src/Infrastructure/Persistence/Repositories/CountryRepository.cs
+++ b/ECommercePlateform.Server/src/Infrastructure/Persistence/Repositories/CountryRepository.cs
@@ -32,25 +32,25 @@ namespace ECommercePlateform.Server.Infrastructure.Persistence.Repositories
         public async Task<bool> IsNameUniqueAsync(string name)
         {
             return !await _context.Countries
-                .AnyAsync(c => c.Name.ToLower() == name.ToLower() && !c.IsDeleted);
+                .AnyAsync(c => c.Name.ToLower().Trim() == name.ToLower().Trim() && !c.IsDeleted);
         }
 
         public async Task<bool> IsCodeUniqueAsync(string code)
         {
             return !await _context.Countries
-                .AnyAsync(c => c.Code.ToLower() == code.ToLower() && !c.IsDeleted);
+                .AnyAsync(c => c.Code.ToLower().Trim() == code.ToLower().Trim() && !c.IsDeleted);
         }
 
         public async Task<bool> IsNameUniqueAsync(string name, Guid excludeId)
         {
             return !await _context.Countries
-                .AnyAsync(c => c.Name.ToLower() == name.ToLower() && c.Id != excludeId && !c.IsDeleted);
+                .AnyAsync(c => c.Name.ToLower().Trim() == name.ToLower().Trim() && c.Id != excludeId && !c.IsDeleted);
         }
 
         public async Task<bool> IsCodeUniqueAsync(string code, Guid excludeId)
         {
             return !await _context.Countries
-                .AnyAsync(c => c.Code.ToLower() == code.ToLower() && c.Id != excludeId && !c.IsDeleted);
+                .AnyAsync(c => c.Code.ToLower().Trim() == code.ToLower().Trim() && c.Id != excludeId && !c.IsDeleted);
         }
     }
 } 

--- a/ECommercePlateform.Server/src/Infrastructure/Persistence/Repositories/StateRepository.cs
+++ b/ECommercePlateform.Server/src/Infrastructure/Persistence/Repositories/StateRepository.cs
@@ -38,25 +38,25 @@ namespace ECommercePlateform.Server.src.Infrastructure.Persistence.Repositories
         public async Task<bool> IsNameUniqueInCountryAsync(string name, Guid countryId)
         {
             return !await _context.States
-                .AnyAsync(s => s.Name.ToLower() == name.ToLower() && s.CountryId == countryId && !s.IsDeleted);
+                .AnyAsync(s => s.Name.ToLower().Trim() == name.ToLower().Trim() && s.CountryId == countryId && !s.IsDeleted);
         }
 
         public async Task<bool> IsCodeUniqueInCountryAsync(string code, Guid countryId)
         {
             return !await _context.States
-                .AnyAsync(s => s.Code.ToLower() == code.ToLower() && s.CountryId == countryId && !s.IsDeleted);
+                .AnyAsync(s => s.Code.ToLower().Trim() == code.ToLower().Trim() && s.CountryId == countryId && !s.IsDeleted);
         }
 
         public async Task<bool> IsNameUniqueInCountryAsync(string name, Guid countryId, Guid excludeId)
         {
             return !await _context.States
-                .AnyAsync(s => s.Name.ToLower() == name.ToLower() && s.CountryId == countryId && s.Id != excludeId && !s.IsDeleted);
+                .AnyAsync(s => s.Name.ToLower().Trim() == name.ToLower().Trim() && s.CountryId == countryId && s.Id != excludeId && !s.IsDeleted);
         }
 
         public async Task<bool> IsCodeUniqueInCountryAsync(string code, Guid countryId, Guid excludeId)
         {
             return !await _context.States
-                .AnyAsync(s => s.Code.ToLower() == code.ToLower() && s.CountryId == countryId && s.Id != excludeId && !s.IsDeleted);
+                .AnyAsync(s => s.Code.ToLower().Trim() == code.ToLower().Trim() && s.CountryId == countryId && s.Id != excludeId && !s.IsDeleted);
         }
 
     }

--- a/ecommerceplateform.client/src/app/admin/city/city.component.html
+++ b/ecommerceplateform.client/src/app/admin/city/city.component.html
@@ -71,6 +71,7 @@
             <div *ngIf="cityForm.get('name')?.touched && cityForm.get('name')?.errors" class="error-message">
               <div *ngIf="cityForm.get('name')?.errors?.['required']">City name is required</div>
               <div *ngIf="cityForm.get('name')?.errors?.['maxlength']">City name must be less than 100 characters</div>
+              <div *ngIf="cityForm.get('name')?.errors?.['whitespace']">City name cannot contain only whitespace</div>
             </div>
           </div>
           

--- a/ecommerceplateform.client/src/app/admin/city/city.component.ts
+++ b/ecommerceplateform.client/src/app/admin/city/city.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule, ValidatorFn, AbstractControl } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { City } from '../../models/city.model';
@@ -32,6 +32,15 @@ export class CityComponent implements OnInit, OnDestroy {
   message: Message | null = null;
   private currentUser: any = null;
   private messageSubscription!: Subscription;
+
+  noWhitespaceValidator(): ValidatorFn {
+    return (control: AbstractControl): { [key: string]: any } | null => {
+      // Check if the value exists and if it contains only whitespace
+      const isWhitespace = control.value && control.value.trim().length === 0;
+      // Return validation error if true, otherwise null
+      return isWhitespace ? { 'whitespace': true } : null;
+    };
+  }
 
   constructor(
     private cityService: CityService,
@@ -66,7 +75,7 @@ export class CityComponent implements OnInit, OnDestroy {
 
   private initForm(): void {
     this.cityForm = this.fb.group({
-      name: ['', [Validators.required, Validators.maxLength(100)]],
+      name: ['', [Validators.required, Validators.maxLength(100), this.noWhitespaceValidator()]],
       stateId: ['', [Validators.required]]
     });
   }

--- a/ecommerceplateform.client/src/app/admin/country/country.component.html
+++ b/ecommerceplateform.client/src/app/admin/country/country.component.html
@@ -39,6 +39,7 @@
             <div *ngIf="countryForm.get('name')?.touched && countryForm.get('name')?.errors" class="error-message">
               <div *ngIf="countryForm.get('name')?.errors?.['required']">Country name is required</div>
               <div *ngIf="countryForm.get('name')?.errors?.['maxlength']">Country name must be less than 100 characters</div>
+              <div *ngIf="countryForm.get('name')?.errors?.['whitespace']">Country name cannot contain only whitespace</div>
             </div>
           </div>
           
@@ -54,6 +55,7 @@
             <div *ngIf="countryForm.get('code')?.touched && countryForm.get('code')?.errors" class="error-message">
               <div *ngIf="countryForm.get('code')?.errors?.['required']">Country code is required</div>
               <div *ngIf="countryForm.get('code')?.errors?.['maxlength']">Country code must be less than 10 characters</div>
+              <div *ngIf="countryForm.get('name')?.errors?.['whitespace']">Country code cannot contain only whitespace</div>
             </div>
           </div>
           

--- a/ecommerceplateform.client/src/app/admin/state/state.component.html
+++ b/ecommerceplateform.client/src/app/admin/state/state.component.html
@@ -55,6 +55,7 @@
             <div *ngIf="stateForm.get('name')?.touched && stateForm.get('name')?.errors" class="error-message">
               <div *ngIf="stateForm.get('name')?.errors?.['required']">State name is required</div>
               <div *ngIf="stateForm.get('name')?.errors?.['maxlength']">State name must be less than 100 characters</div>
+              <div *ngIf="stateForm.get('name')?.errors?.['whitespace']">State name cannot contain only whitespace</div>
             </div>
           </div>
           
@@ -70,6 +71,7 @@
             <div *ngIf="stateForm.get('code')?.touched && stateForm.get('code')?.errors" class="error-message">
               <div *ngIf="stateForm.get('code')?.errors?.['required']">State code is required</div>
               <div *ngIf="stateForm.get('code')?.errors?.['maxlength']">State code must be less than 10 characters</div>
+              <div *ngIf="stateForm.get('name')?.errors?.['whitespace']">State code cannot contain only whitespace</div>
             </div>
           </div>
           

--- a/ecommerceplateform.client/src/app/admin/state/state.component.ts
+++ b/ecommerceplateform.client/src/app/admin/state/state.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule, FormsModule, ValidatorFn, AbstractControl } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { State } from '../../models/state.model';
@@ -28,6 +28,15 @@ export class StateComponent implements OnInit {
   message: Message | null = null;
   private currentUser: any = null;
   private messageSubscription!: Subscription;
+
+  noWhitespaceValidator(): ValidatorFn {
+    return (control: AbstractControl): { [key: string]: any } | null => {
+      // Check if the value exists and if it contains only whitespace
+      const isWhitespace = control.value && control.value.trim().length === 0;
+      // Return validation error if true, otherwise null
+      return isWhitespace ? { 'whitespace': true } : null;
+    };
+  }
 
   constructor(
     private stateService: StateService,
@@ -60,8 +69,8 @@ export class StateComponent implements OnInit {
 
   private initForm(): void {
     this.stateForm = this.fb.group({
-      name: ['', [Validators.required, Validators.maxLength(100)]],
-      code: ['', [Validators.required, Validators.maxLength(10)]],
+      name: ['', [Validators.required, Validators.maxLength(100), this.noWhitespaceValidator()]],
+      code: ['', [Validators.required, Validators.maxLength(10), this.noWhitespaceValidator()]],
       countryId: ['', [Validators.required]]
     });
   }

--- a/ecommerceplateform.client/src/app/services/no-white-space.service.spec.ts
+++ b/ecommerceplateform.client/src/app/services/no-white-space.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NoWhiteSpaceService } from './no-white-space.service';
+
+describe('NoWhiteSpaceService', () => {
+  let service: NoWhiteSpaceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NoWhiteSpaceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/ecommerceplateform.client/src/app/services/no-white-space.service.ts
+++ b/ecommerceplateform.client/src/app/services/no-white-space.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { ValidatorFn, AbstractControl } from '@angular/forms';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NoWhiteSpaceService {
+
+  constructor() { }
+
+  noWhitespaceValidator(): ValidatorFn {
+  return (control: AbstractControl): { [key: string]: any } | null => {
+    const isWhitespace = (control.value || '').trim().length === 0;
+    return isWhitespace ? { whitespace: true } : null;
+  };
+}
+}


### PR DESCRIPTION
Implement a custom `noWhitespaceValidator` across City, Country, and State components to prevent whitespace-only input. Update repository methods to trim whitespace for uniqueness checks. Enhance HTML templates to display relevant error messages. Create `NoWhiteSpaceService` for validation logic and add unit tests. Modify form initialization to include the new validator.